### PR TITLE
Declared 'zero' as int

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -1,5 +1,5 @@
 #include "ACS712.h"
-
+int zero; 
 ACS712::ACS712(ACS712_type type, uint8_t _pin) {
 	switch (type) {
 		case ACS712_05B:


### PR DESCRIPTION
In the setZeroPoint() method, 'zero' was not declared or Initialized. 
Arduino IDE was giving error of 'zero not declared or defined'
I declared it as 'int' because it's taking an int value as a parameter.