### PR TITLE
Fixed typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ACS712
 ======
-An Arduino library to interact with the ACS712 Hall effect-based linear current sensor. Includes DC and RMS AC current measuring. Supports ACS712-05B, ACS712-10A, ACS712-30A sensors. Typical applications include motor control, load detection and management, switch mode power supplies, and overcurrent fault protection.
+An Arduino library to interact with the ACS712 Hall effect-based linear current sensor. Includes DC and RMS AC current measuring. Supports ACS712-05B, ACS712-20A, ACS712-30A sensors. Typical applications include motor control, load detection and management, switch mode power supplies, and overcurrent fault protection.
 
 For more information see the datasheet: http://www.allegromicro.com/~/media/files/datasheets/acs712-datasheet.ashx
 


### PR DESCRIPTION
Looks like there are no settings set for `ACS712-10A` but there are settings for `ACS712-20A`.

Library works great, thank you!