### PR TITLE
exposed setZeroPoint as method of ACS712 and added example how to use it

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -29,7 +29,7 @@ int ACS712::calibrate() {
 	return _zero;
 }
 
-void setZeroPoint(int _zero) {
+void ACS712::setZeroPoint(int _zero) {
 	zero = _zero;
 }
 

--- a/examples/SetZeroPoint/SetZeroPoint.ino
+++ b/examples/SetZeroPoint/SetZeroPoint.ino
@@ -1,0 +1,18 @@
+#include "ACS712.h"
+
+/*
+  This example shows how to set zero point of your sensor
+*/
+
+// We have 30 amps version sensor connected to A1 pin of arduino
+// Replace with your version if necessary
+ACS712 sensor(ACS712_30A, A1);
+
+void setup() {
+  Serial.begin(9600);
+
+  // Value obtained using sensor.calibrate() when no current flows through the sensor
+  sensor.setZeroPoint(438);
+}
+
+void loop() {}


### PR DESCRIPTION
There was no access to setZeroPoint function which prevented from configuring it.

From now on it will be available as `sensor.setZeroPoint(int zero);`