### PR TITLE
Calibration Error Solved During AC Current Flow throw the Sensor

### DIFF
--- a/ACS712.cpp
+++ b/ACS712.cpp
@@ -20,11 +20,11 @@ ACS712::ACS712(ACS712_type type, uint8_t _pin) {
 
 int ACS712::calibrate() {
 	int _zero = 0;
-	for (int i = 0; i < 10; i++) {
+	for (int i = 0; i < 20; i++) {
 		_zero += analogRead(pin);
-		delay(10);
+		delay(1);
 	}
-	_zero /= 10;
+	_zero /= 20;
 	zero = _zero;
 	return _zero;
 }


### PR DESCRIPTION
calibrate() method calibrates zero point of sensor,
It is not necessary, but may positively affect the accuracy. Our line frequency is 50Hz where the time period is about 20ms. So if we apply an operation on a single cycle then we get the actual zero point during ac current is flowed. And here the solution by sampling 20  times a single cycle . It takes less time plus full cycle operation to avoid error.